### PR TITLE
IS-14 rename and simplify

### DIFF
--- a/Development/nmos-cpp-node/node_implementation.cpp
+++ b/Development/nmos-cpp-node/node_implementation.cpp
@@ -1266,7 +1266,7 @@ void node_implementation_init(nmos::node_model& model, nmos::experimental::contr
                     utility::stringstream_t role;
                     role << U("monitor-") << ++count;
                     const auto& receiver = nmos::find_resource(model.node_resources, receiver_id);
-                    const auto receiver_monitor = nmos::make_receiver_monitor(++oid, true, nmos::root_block_oid, role.str(), nmos::fields::label(receiver->data), nmos::fields::description(receiver->data), value_of({ { nmos::details::make_nc_touchpoint_nmos({nmos::ncp_nmos_resource_types::receiver, receiver_id}) } }));
+                    const auto receiver_monitor = nmos::make_receiver_monitor(++oid, true, nmos::root_block_oid, role.str(), nmos::fields::label(receiver->data), nmos::fields::description(receiver->data), value_of({ { nmos::details::make_nc_touchpoint_nmos({nmos::ncp_touchpoint_resource_types::receiver, receiver_id}) } }));
 
                     // add receiver-monitor to root-block
                     nmos::push_back(root_block, receiver_monitor);

--- a/Development/nmos/control_protocol_methods.cpp
+++ b/Development/nmos/control_protocol_methods.cpp
@@ -513,7 +513,7 @@ namespace nmos
 
     // NcClassManager methods implementation
     // Get a single class descriptor
-    web::json::value get_control_class(nmos::resources&, const nmos::resource&, const web::json::value& arguments, bool is_deprecated, get_control_protocol_class_descriptor_handler get_control_protocol_class_descriptor, slog::base_gate& gate)
+    web::json::value get_control_class(const web::json::value& arguments, bool is_deprecated, get_control_protocol_class_descriptor_handler get_control_protocol_class_descriptor, slog::base_gate& gate)
     {
         using web::json::value;
 
@@ -568,7 +568,7 @@ namespace nmos
     }
 
     // Get a single datatype descriptor
-    web::json::value get_datatype(nmos::resources&, const nmos::resource&, const web::json::value& arguments, bool is_deprecated, get_control_protocol_datatype_descriptor_handler get_control_protocol_datatype_descriptor, slog::base_gate& gate)
+    web::json::value get_datatype(const web::json::value& arguments, bool is_deprecated, get_control_protocol_datatype_descriptor_handler get_control_protocol_datatype_descriptor, slog::base_gate& gate)
     {
         // note, model mutex is already locked by the outer function, so access to control_protocol_resources is OK...
 

--- a/Development/nmos/control_protocol_methods.h
+++ b/Development/nmos/control_protocol_methods.h
@@ -39,9 +39,9 @@ namespace nmos
 
     // NcClassManager methods implementation
     // Get a single class descriptor
-    web::json::value get_control_class(nmos::resources&, const nmos::resource&, const web::json::value& arguments, bool is_deprecated, get_control_protocol_class_descriptor_handler get_control_protocol_class_descriptor, slog::base_gate& gate);
+    web::json::value get_control_class(const web::json::value& arguments, bool is_deprecated, get_control_protocol_class_descriptor_handler get_control_protocol_class_descriptor, slog::base_gate& gate);
     // Get a single datatype descriptor
-    web::json::value get_datatype(nmos::resources&, const nmos::resource&, const web::json::value& arguments, bool is_deprecated, get_control_protocol_datatype_descriptor_handler get_control_protocol_datatype, slog::base_gate& gate);
+    web::json::value get_datatype(const web::json::value& arguments, bool is_deprecated, get_control_protocol_datatype_descriptor_handler get_control_protocol_datatype, slog::base_gate& gate);
 }
 
 #endif

--- a/Development/nmos/control_protocol_nmos_resource_type.h
+++ b/Development/nmos/control_protocol_nmos_resource_type.h
@@ -8,15 +8,15 @@ namespace nmos
 {
     // resourceType
     // See https://specs.amwa.tv/ms-05-02/branches/v1.0.x/docs/Framework.html#nctouchpointresourcenmos
-    DEFINE_STRING_ENUM(ncp_nmos_resource_type)
-    namespace ncp_nmos_resource_types
+    DEFINE_STRING_ENUM(ncp_touchpoint_resource_type)
+    namespace ncp_touchpoint_resource_types
     {
-        const ncp_nmos_resource_type node{ U("node") };
-        const ncp_nmos_resource_type device{ U("device") };
-        const ncp_nmos_resource_type source{ U("source") };
-        const ncp_nmos_resource_type flow{ U("flow") };
-        const ncp_nmos_resource_type sender{ U("sender") };
-        const ncp_nmos_resource_type receiver{ U("receiver") };
+        const ncp_touchpoint_resource_type node{ U("node") };
+        const ncp_touchpoint_resource_type device{ U("device") };
+        const ncp_touchpoint_resource_type source{ U("source") };
+        const ncp_touchpoint_resource_type flow{ U("flow") };
+        const ncp_touchpoint_resource_type sender{ U("sender") };
+        const ncp_touchpoint_resource_type receiver{ U("receiver") };
     }
 }
 

--- a/Development/nmos/control_protocol_state.cpp
+++ b/Development/nmos/control_protocol_state.cpp
@@ -167,16 +167,16 @@ namespace nmos
             }
             nmos::experimental::control_protocol_method_handler make_nc_get_control_class_handler(get_control_protocol_class_descriptor_handler get_control_protocol_class_descriptor)
             {
-                return [get_control_protocol_class_descriptor](nmos::resources& resources, const nmos::resource& resource, const web::json::value& arguments, bool is_deprecated, slog::base_gate& gate)
+                return [get_control_protocol_class_descriptor](nmos::resources&, const nmos::resource&, const web::json::value& arguments, bool is_deprecated, slog::base_gate& gate)
                 {
-                    return get_control_class(resources, resource, arguments, is_deprecated, get_control_protocol_class_descriptor, gate);
+                    return get_control_class(arguments, is_deprecated, get_control_protocol_class_descriptor, gate);
                 };
             }
             nmos::experimental::control_protocol_method_handler make_nc_get_datatype_handler(get_control_protocol_datatype_descriptor_handler get_control_protocol_datatype_descriptor)
             {
-                return [get_control_protocol_datatype_descriptor](nmos::resources& resources, const nmos::resource& resource, const web::json::value& arguments, bool is_deprecated, slog::base_gate& gate)
+                return [get_control_protocol_datatype_descriptor](nmos::resources&, const nmos::resource&, const web::json::value& arguments, bool is_deprecated, slog::base_gate& gate)
                 {
-                    return get_datatype(resources, resource, arguments, is_deprecated, get_control_protocol_datatype_descriptor, gate);
+                    return get_datatype(arguments, is_deprecated, get_control_protocol_datatype_descriptor, gate);
                 };
             }
             nmos::experimental::control_protocol_method_handler make_nc_get_properties_by_path_handler(get_control_protocol_class_descriptor_handler get_control_protocol_class_descriptor, get_control_protocol_datatype_descriptor_handler get_control_protocol_datatype_descriptor, get_properties_by_path_handler get_properties_by_path)

--- a/Development/nmos/control_protocol_typedefs.h
+++ b/Development/nmos/control_protocol_typedefs.h
@@ -385,7 +385,7 @@ namespace nmos
             , id(id)
         {}
 
-        nc_touchpoint_resource_nmos(const ncp_nmos_resource_type& resource_type, nc_uuid id)
+        nc_touchpoint_resource_nmos(const ncp_touchpoint_resource_type& resource_type, nc_uuid id)
             : nc_touchpoint_resource(resource_type.name)
             , id(id)
         {}

--- a/Development/nmos/control_protocol_utils.cpp
+++ b/Development/nmos/control_protocol_utils.cpp
@@ -623,8 +623,7 @@ namespace nmos
                 auto found_tp = std::find_if(tps.begin(), tps.end(), [resource_id](const web::json::value& touchpoint)
                 {
                     auto& resource = nmos::fields::nc::resource(touchpoint);
-                    return (resource_id == nmos::fields::nc::id(resource).as_string()
-                        && nmos::ncp_touchpoint_resource_types::receiver.name == nmos::fields::nc::resource_type(resource));
+                    return (resource_id == nmos::fields::nc::id(resource).as_string());
                 });
                 return (tps.end() != found_tp);
             }

--- a/Development/nmos/control_protocol_utils.cpp
+++ b/Development/nmos/control_protocol_utils.cpp
@@ -624,7 +624,7 @@ namespace nmos
                 {
                     auto& resource = nmos::fields::nc::resource(touchpoint);
                     return (resource_id == nmos::fields::nc::id(resource).as_string()
-                        && nmos::ncp_nmos_resource_types::receiver.name == nmos::fields::nc::resource_type(resource));
+                        && nmos::ncp_touchpoint_resource_types::receiver.name == nmos::fields::nc::resource_type(resource));
                 });
                 return (tps.end() != found_tp);
             }


### PR DESCRIPTION
- Changed `ncp_nmos_resource_type` to `ncp_touchpoint_resource_type`
- Generalized `find_control_protocol_resource` (removed explicit references to Receiver resources)
- Removed redundant parameters from `get_control_class` and `get_datatype`